### PR TITLE
styled-components ^v6.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "react": "^18",
     "rxjs": "^7.8.0",
     "sanity": "^3",
-    "styled-components": "^5.3.6"
+    "styled-components": "^5.3.6 || ^6.0.0"
   },
   "engines": {
     "node": ">=14"


### PR DESCRIPTION
Without ^6.0.0 for styled-components dependency, would get the following warning while installing packages:
```
 WARN  Issues with peer dependencies found
.
└─┬ sanity-plugin-tags 2.0.1
  └── ✕ unmet peer styled-components@^5.3.6: found 6.1.1
```

Including v6 and up should be safe because the plugin does not use any of the features that had breaking changes between v5 and v6.