### PR TITLE
Adds a temporary work around for Cannot read properties of undefined (reading 'ReactCurrentDispatcher')

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
   },
   "peerDependencies": {
     "react": "^18",
+    "react-dom": "^18",
     "rxjs": "^7.8.0",
     "sanity": "^3",
     "styled-components": "^5.3.6 || ^6.0.0"


### PR DESCRIPTION
Should help with #37 

May need further testing, but was able to get around ReactCurrentDispatcher issue with it.

Ideally package would be updated to React 19